### PR TITLE
fix: 解决单击非时间日期单元格后还会跳出日期时间弹框

### DIFF
--- a/src/controllers/cellDatePickerCtrl.js
+++ b/src/controllers/cellDatePickerCtrl.js
@@ -75,7 +75,7 @@ const cellDatePickerCtrl = {
             time_24hr = false;
         }
 
-        flatpickr('#luckysheet-input-box', {
+        const fp = flatpickr('#luckysheet-input-box', {
             allowInput: false,
             noCalendar,
             enableSeconds,
@@ -83,6 +83,11 @@ const cellDatePickerCtrl = {
             dateFormat,
             time_24hr,
             defaultDate,
+            onClose() {
+                setTimeout(() => {
+                    fp.destroy()
+                }, 0);
+            },
             parseDate: (datestr, format) => {
                 return dayjs(datestr).toDate();
             },


### PR DESCRIPTION
之前没有测到这个bug;今天看到有人提，就解决了下