### PR TITLE
formula.js公式修改

### DIFF
--- a/src/function/func.js
+++ b/src/function/func.js
@@ -1605,7 +1605,7 @@ function luckysheet_getcelldata(txt) {
         sheetdata = null;
     
     if (val.length > 1) {
-        sheettxt = val[0];
+        sheettxt = val[0].replace(/''/g,"'");
         rangetxt = val[1];
 
         if(sheettxt.substr(0,1)=="'" && sheettxt.substr(sheettxt.length-1,1)=="'"){


### PR DESCRIPTION
主要修改了src/global/formula.js的functionParser、isFunctionRange、execFunctionGroup、execfunction、functionHTML、getcellrange函数中与单、双引号处理的代码。

1、现在能处理="3"+3&""""""""这类带“”公式，输出结果为6"""
2、能处理sheet名字包含-()等字符以及包含单引号'【但不能在首尾位置】例如：Sheet2重命名为"1'-2(副本) 公式为='"1''-2(副本)'!A1就能正确引用"1'-2(副本)表A1单元格内容
3、修改了functionHTML让输入='1-2'!A1时候原本2'!A1是红色，'1-是黑色的问题。
4、修复了A1为5，A2公式=A1，A3公式=A1+A2，删除A1的值后，A3变成#VALUE!的错误。