### PR TITLE
修改了src/methods/get.js的getRangetxt

### DIFF
--- a/src/controllers/sheetBar.js
+++ b/src/controllers/sheetBar.js
@@ -281,9 +281,12 @@ export function initialSheetBar(){
 
         let $t = $(this);
         let txt = $t.text(), oldtxt = $t.data("oldtxt");
-        var reg1 = new RegExp("[\\[\\]:\\?*\/'\"]");
-        if(reg1.test(txt)){
+        if(txt.length>31 || txt.charAt(0)=="'" || txt.charAt(txt.length-1)=="'" || /[：\:\\\/？\?\*\[\]]+/.test(txt)){
             alert(locale_sheetconfig.sheetNameSpecCharError);
+            setTimeout(()=>{
+                luckysheetsheetnameeditor($(this));
+                $(this).focus();
+            }, 1);
             return;
         }
 

--- a/src/locale/zh.js
+++ b/src/locale/zh.js
@@ -9769,7 +9769,7 @@ export default {
         redoDelete:"可以通过Ctrl+Z撤销删除",
         noHide:"不能隐藏, 至少保留一个sheet标签",
         chartEditNoOpt:"图表编辑模式下不允许该操作！",
-        sheetNameSpecCharError:"名称不能包含:[ ] : \ ? * / ' \"",
+        sheetNameSpecCharError:"名称不能超过31个字符，首尾不能是' 且名称不能包含:\r\n[ ] : \\ ? * /",
         sheetNamecannotIsEmptyError:"名称不能为空"
     },
     conditionformat: {

--- a/src/methods/get.js
+++ b/src/methods/get.js
@@ -19,7 +19,17 @@ function getRangetxt(sheetIndex, range, currentIndex) {
     }
 
     if (sheetIndex != currentIndex) {
-        sheettxt = Store.luckysheetfile[getSheetIndex(sheetIndex)].name + "!";
+        //sheet名字包含'的，引用时应该替换为''
+        sheettxt = Store.luckysheetfile[getSheetIndex(sheetIndex)].name.replace(/'/g,"''");
+        //如果包含除a-z、A-Z、0-9、下划线等以外的字符那么就用单引号包起来
+        if(/^[:A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD][:A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\-.0-9\u00B7\u0300-\u036F\u203F-\u2040]*$/.test(sheettxt))
+        {
+            sheettxt = sheettxt+"!";
+        }
+        else
+        {
+            sheettxt="'"+sheettxt+"'!";
+        }
     }
 
     let row0 = range["row"][0], row1 = range["row"][1];


### PR DESCRIPTION
修改了src/methods/get.js的getRangetxt函数。

解决了在单元格输入=后鼠标选择其他sheet的单元格后，公式栏显示公式不根据情况都不加单引号的bug。例如：sheet2重命名为1-2，在sheet1里A1单元格输入=后，鼠标点1-2的A1单元格后，公式栏显示公式=1-2!A1，这种公式是错误的。正确应该是='1-2'!A1