### PR TITLE
解决合并单元格后取消合并操作创建cell的地址引用问题

### DIFF
--- a/src/controllers/menuButton.js
+++ b/src/controllers/menuButton.js
@@ -3204,7 +3204,8 @@ const menuButton = {
                                 fv[mc_r + "_" + mc_c] = $.extend(true, {}, cell);
                             }
                             else{
-                                let cell_clone = fv[mc_r + "_" + mc_c];
+                                // let cell_clone = fv[mc_r + "_" + mc_c];
+                                let cell_clone = JSON.parse(JSON.stringify(fv[mc_r + "_" + mc_c]));
 
                                 delete cell_clone.v;
                                 delete cell_clone.m;
@@ -3265,7 +3266,8 @@ const menuButton = {
                                     fv[mc_r + "_" + mc_c] = $.extend(true, {}, cell);
                                 }
                                 else{
-                                    let cell_clone = fv[mc_r + "_" + mc_c];
+                                let cell_clone = fv[mc_r + "_" + mc_c];
+                                let cell_clone = JSON.parse(JSON.stringify(fv[mc_r + "_" + mc_c]));
 
                                     delete cell_clone.v;
                                     delete cell_clone.m;

--- a/src/global/api.js
+++ b/src/global/api.js
@@ -3163,7 +3163,8 @@ export function cancelRangeMerge(options = {}) {
                         fv[mc_r + "_" + mc_c] = $.extend(true, {}, cell);
                     }
                     else{
-                        let cell_clone = fv[mc_r + "_" + mc_c];
+                        // let cell_clone = fv[mc_r + "_" + mc_c];
+                        let cell_clone = JSON.parse(JSON.stringify(fv[mc_r + "_" + mc_c]));
 
                         delete cell_clone.v;
                         delete cell_clone.m;


### PR DESCRIPTION
操作步骤： 
（1）合并单元格
（2）取消合并单元格
（3）在取消合并后的某个单元格内编辑内容
问题描述：
  整块区域的N个单元格联动（设置了某个单元格的内容为 “优秀”，则周边合并单元格范围内所有的单元格都被设置为 “优秀”）