### PR TITLE
docs(config.md): 修复 cellRenderBefore 和 cellRenderAfter 中关于单元格坐标位置的描述

### DIFF
--- a/docs/zh/guide/config.md
+++ b/docs/zh/guide/config.md
@@ -921,10 +921,10 @@ Luckysheet开放了更细致的自定义配置选项，分别有
 	- {Object} [position]:
 		+ {Number} [r]:单元格所在行号
 		+ {Number} [c]:单元格所在列号
-		+ {Number} [start_r]:单元格左上角的水平坐标
-		+ {Number} [start_c]:单元格左上角的垂直坐标
-		+ {Number} [end_r]:单元格右下角的水平坐标
-		+ {Number} [end_c]:单元格右下角的垂直坐标
+		+ {Number} [start_r]:单元格左上角的垂直坐标
+		+ {Number} [start_c]:单元格左上角的水平坐标
+		+ {Number} [end_r]:单元格右下角的垂直坐标
+		+ {Number} [end_c]:单元格右下角的水平坐标
 	- {Object} [sheet]:当前sheet对象
 	- {Object} [ctx]: 当前画布的context
 
@@ -939,10 +939,10 @@ Luckysheet开放了更细致的自定义配置选项，分别有
 	- {Object} [position]:
 		+ {Number} [r]:单元格所在行号
 		+ {Number} [c]:单元格所在列号
-		+ {Number} [start_r]:单元格左上角的水平坐标
-		+ {Number} [start_c]:单元格左上角的垂直坐标
-		+ {Number} [end_r]:单元格右下角的水平坐标
-		+ {Number} [end_c]:单元格右下角的垂直坐标
+		+ {Number} [start_r]:单元格左上角的垂直坐标
+		+ {Number} [start_c]:单元格左上角的水平坐标
+		+ {Number} [end_r]:单元格右下角的垂直坐标
+		+ {Number} [end_c]:单元格右下角的水平坐标
 	- {Object} [sheet]:当前sheet对象
 	- {Object} [ctx]: 当前画布的context
 
@@ -957,10 +957,10 @@ Luckysheet开放了更细致的自定义配置选项，分别有
 	- {Object} [position]:
 		+ {Number} [r]:单元格所在行号
 		+ {Number} [c]:单元格所在列号
-		+ {Number} [start_r]:单元格左上角的水平坐标
-		+ {Number} [start_c]:单元格左上角的垂直坐标
-		+ {Number} [end_r]:单元格右下角的水平坐标
-		+ {Number} [end_c]:单元格右下角的垂直坐标
+		+ {Number} [start_r]:单元格左上角的垂直坐标
+		+ {Number} [start_c]:单元格左上角的水平坐标
+		+ {Number} [end_r]:单元格右下角的垂直坐标
+		+ {Number} [end_c]:单元格右下角的水平坐标
 	- {Object} [sheet]:当前sheet对象
 	- {Object} [moveState]:鼠标移动状态，可判断现在鼠标操作的对象，false和true
 		+ {Boolean} [functionResizeStatus]:工具栏拖动
@@ -993,10 +993,10 @@ Luckysheet开放了更细致的自定义配置选项，分别有
 	- {Object} [position]:
 		+ {Number} [r]:单元格所在行号
 		+ {Number} [c]:单元格所在列号
-		+ {Number} [start_r]:单元格左上角的水平坐标
-		+ {Number} [start_c]:单元格左上角的垂直坐标
-		+ {Number} [end_r]:单元格右下角的水平坐标
-		+ {Number} [end_c]:单元格右下角的垂直坐标
+		+ {Number} [start_r]:单元格左上角的垂直坐标
+		+ {Number} [start_c]:单元格左上角的水平坐标
+		+ {Number} [end_r]:单元格右下角的垂直坐标
+		+ {Number} [end_c]:单元格右下角的水平坐标
 	- {Object} [sheet]:当前sheet对象
 	- {Object} [moveState]:鼠标移动状态，可判断现在鼠标操作的对象，false和true
 		+ {Boolean} [functionResizeStatus]:工具栏拖动
@@ -1046,10 +1046,10 @@ Luckysheet开放了更细致的自定义配置选项，分别有
 	- {Object} [position]:
 		+ {Number} [r]:单元格所在行号
 		+ {Number} [c]:单元格所在列号
-		+ {Number} [start_r]:单元格左上角的水平坐标
-		+ {Number} [start_c]:单元格左上角的垂直坐标
-		+ {Number} [end_r]:单元格右下角的水平坐标
-		+ {Number} [end_c]:单元格右下角的垂直坐标
+		+ {Number} [start_r]:单元格左上角的垂直坐标
+		+ {Number} [start_c]:单元格左上角的水平坐标
+		+ {Number} [end_r]:单元格右下角的垂直坐标
+		+ {Number} [end_c]:单元格右下角的水平坐标
 	- {Object} [sheet]:当前sheet对象
 	- {Object} [ctx]: 当前画布的context
 	- {Object} [event]: 当前事件对象

--- a/docs/zh/guide/config.md
+++ b/docs/zh/guide/config.md
@@ -743,10 +743,10 @@ Luckysheet开放了更细致的自定义配置选项，分别有
 	- {Object} [position]:
 		+ {Number} [r]:单元格所在行号
 		+ {Number} [c]:单元格所在列号
-		+ {Number} [start_r]:单元格左上角的水平坐标
-		+ {Number} [start_c]:单元格左上角的垂直坐标
-		+ {Number} [end_r]:单元格右下角的水平坐标
-		+ {Number} [end_c]:单元格右下角的垂直坐标
+		+ {Number} [start_r]:单元格左上角的垂直坐标
+		+ {Number} [start_c]:单元格左上角的水平坐标
+		+ {Number} [end_r]:单元格右下角的垂直坐标
+		+ {Number} [end_c]:单元格右下角的水平坐标
 	- {Object} [sheet]:当前sheet对象
 	- {Object} [ctx]: 当前画布的context
 
@@ -761,10 +761,10 @@ Luckysheet开放了更细致的自定义配置选项，分别有
 	- {Object} [position]:
 		+ {Number} [r]:单元格所在行号
 		+ {Number} [c]:单元格所在列号
-		+ {Number} [start_r]:单元格左上角的水平坐标
-		+ {Number} [start_c]:单元格左上角的垂直坐标
-		+ {Number} [end_r]:单元格右下角的水平坐标
-		+ {Number} [end_c]:单元格右下角的垂直坐标
+		+ {Number} [start_r]:单元格左上角的垂直坐标
+		+ {Number} [start_c]:单元格左上角的水平坐标
+		+ {Number} [end_r]:单元格右下角的垂直坐标
+		+ {Number} [end_c]:单元格右下角的水平坐标
 	- {Object} [sheet]:当前sheet对象
 	- {Object} [ctx]: 当前画布的context
 


### PR DESCRIPTION
docs(config.md): 修复 cellRenderBefore 和 cellRenderAfter 中关于单元格坐标位置的描述