### PR TITLE
添加自定义图片同步方法的功能

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -66,4 +66,5 @@ export default {
     showstatisticBarConfig:{}, //自定义计数栏
     cellRightClickConfig:{}, //自定义单元格右键菜单
     sheetRightClickConfig:{}, //自定义底部sheet页右击菜单
+    imageUpdateMethodConfig:{}, //自定义图片同步方式
 }

--- a/src/controllers/imageUpdateCtrl.js
+++ b/src/controllers/imageUpdateCtrl.js
@@ -1,0 +1,21 @@
+// 自定义图片的更新方法例如: customImageUpdate("POST", "http://127.0.0.1:8000/luckysheetimageprocess/", d)
+function customImageUpdate(method, url, obj) {
+    return new Promise((resolve, reject) => {
+        const xhr = new XMLHttpRequest() || new ActiveXObject("Microsoft.XMLHTTP");
+        xhr.open(method, url);
+        xhr.send(JSON.stringify(obj)); // 发送 POST/GET 数据
+        xhr.onreadystatechange = function () {
+            if (xhr.readyState == 4) {
+                if (xhr.status == 200) {
+                    resolve(xhr.responseText);
+                } else {
+                    reject("error");
+                }
+            }
+        };
+    });
+}
+
+export {
+    customImageUpdate
+}

--- a/src/controllers/server.js
+++ b/src/controllers/server.js
@@ -18,6 +18,8 @@ import { collaborativeEditBox } from './select'
 import locale from '../locale/locale';
 import dayjs from "dayjs";
 import json from '../global/json';
+import luckysheetConfigsetting from './luckysheetConfigsetting';
+import {customImageUpdate} from './imageUpdateCtrl';
 
 const server = {
     gridKey: null,
@@ -141,11 +143,31 @@ const server = {
 	        // d.s = params.s;
 	    }
 
-	    let msg = pako.gzip(encodeURIComponent(JSON.stringify(d)), { to: "string" });
+	    // TODO 配置自定义方式同步图片
+        const customImageUpdateMethodConfig = luckysheetConfigsetting.imageUpdateMethodConfig
+		if (JSON.stringify(customImageUpdateMethodConfig) !== "{}") {
+            if ("images" != d.k) {
+                let msg = pako.gzip(encodeURIComponent(JSON.stringify(d)), {to: "string"});
 
-		if(_this.websocket!=null){
-			_this.websocket.send(msg);
-		}
+                if (_this.websocket != null) {
+                    _this.websocket.send(msg);
+                }
+            } else {
+                customImageUpdate(customImageUpdateMethodConfig.method, customImageUpdateMethodConfig.url, d)
+                    .then((data) => {
+                        console.log(data);
+                    })
+                    .catch((err) => {
+                        console.log(err);
+                    });
+
+            }
+        } else {
+            let msg = pako.gzip(encodeURIComponent(JSON.stringify(d)), {to: "string"});
+            if (_this.websocket != null) {
+                _this.websocket.send(msg);
+            }
+        }
 
 	},
     websocket: null,

--- a/src/core.js
+++ b/src/core.js
@@ -140,6 +140,8 @@ luckysheet.create = function (setting) {
 
     luckysheetConfigsetting.initShowsheetbarConfig = false;
 
+    luckysheetConfigsetting.imageUpdateMethodConfig = extendsetting.imageUpdateMethodConfig;
+
     if (Store.lang === 'zh') flatpickr.localize(Mandarin.zh);
 
     // Store the currently used plugins for monitoring asynchronous loading


### PR DESCRIPTION
由于当前使用websocket同步消息，所以遇到较大的图片的时候，就会发生wss连接异常导致wss断开的现象，因此我添加了全局自定义图片同步方法的功能，可以自定义图片发给后台的方式，比如ajax方式，该方法已经用到了我自己的项目里面了，我的项目最终使用ajax提交图片到后台，后台wss传到前台。参考：https://github.com/liuqiao1995/luckysheet_django，

该功能提交id： https://github.com/liuqiao1995/Luckysheet/commit/5b00ea2cced8e228f2b7cd02385e9092c3618c9a

为实现该功能最终添加了如下代码：

1. 首先src/config.js里面添加自定义图片的发送配置
2. 把该配置添加到src/core.js里面
3. 添加一个自定义src/controllers/imageUpdateCtrl.js文件，把发送图片函数写进去
4. src/controllers/server.js里面修改原来的wss发送配置

该功能使用方法如下（可自行修改）：
src/config.js里面修改imageUpdateMethodConfig配置：:{"method":"POST", "url":"http://127.0.0.1:8000/luckysheetupdateurl"}

