### PR TITLE
样式优化，工具栏在拖动高度后单元格下拉仍居中显示

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,6 +32,13 @@ const babel = require('@rollup/plugin-babel').default;
 // Distinguish development and production environments
 const production = process.env.NODE_ENV === 'production' ? true : false;
 
+const pkg = require('./package.json');
+const banner = `/*! @preserve
+ * ${pkg.name}
+ * version: ${pkg.version}
+ * https://github.com/mengshukeji/Luckysheet
+ */`;
+
 // uglify js Compression configuration https://github.com/mishoo/UglifyJS#minify-options
 const uglifyOptions = {
     compress: {
@@ -192,7 +199,7 @@ async function core() {
         name: 'luckysheet',
         sourcemap: true,
         inlineDynamicImports:true,
-
+        banner: banner
     });
 
     if(production){
@@ -202,6 +209,7 @@ async function core() {
             name: 'luckysheet',
             sourcemap: true,
             inlineDynamicImports:true,
+            banner: banner
         });
     }
 

--- a/src/controllers/constant.js
+++ b/src/controllers/constant.js
@@ -45,7 +45,7 @@ const gridHTML = function(){
                                     </div> 
                                 </div>  
                                 <div class="luckysheet-wa-calculate-help-tool">
-                                    <i class="fa fa-caret-down" aria-hidden="true" style="margin-top: 7px;"></i>
+                                    <i class="fa fa-caret-down" aria-hidden="true"></i>
                                 </div> 
                             </div> 
                             <div id="luckysheet-wa-functionbox-cancel" class="luckysheet-wa-functionbox">

--- a/src/css/luckysheet-core.css
+++ b/src/css/luckysheet-core.css
@@ -860,7 +860,8 @@
     left: 0;
     position: absolute;
     right: 0;
-    top: 6px;
+    top: 50%;
+    transform: translateY(-50%);
     resize: none;
     /* border: 1px #b9b9b9 solid; */
     font-family: arial, sans, sans-serif;
@@ -896,6 +897,12 @@
     width: 13px;
     border-left: 1px solid transparent;
     border-right: 1px solid transparent;
+}
+.luckysheet-wa-calculate-help-tool .fa-caret-down {
+    position: absolute;
+    top: 50%;
+    left: 3px;
+    transform: translateY(-50%);
 }
 
 .luckysheet-wa-calculate-help-tool:hover {


### PR DESCRIPTION
原：

![2021-05-07-1](https://user-images.githubusercontent.com/13060680/117390537-f0480c80-af20-11eb-9f66-e6b8e114197e.gif)

新

![2021-05-07-2](https://user-images.githubusercontent.com/13060680/117390545-f50cc080-af20-11eb-8239-70ea373feb88.gif)
