### PR TITLE
fix: 修复数据透视 数据声明bug

### DIFF
--- a/src/controllers/pivotTable.js
+++ b/src/controllers/pivotTable.js
@@ -731,9 +731,7 @@ const pivotTable = {
         redo["type"] = "pivotTable_change";
         redo["curdata"] = $.extend(true, [], data);
         redo["sheetIndex"] = Store.currentSheetIndex;
-
-        let pivotTable = _this.getPivotTableData();
-        redo["pivotTablecur"] = pivotTable; 
+        redo["pivotTablecur"] = _this.getPivotTableData();
 
         if(Store.clearjfundo){
             Store.jfundo.length  = 0;


### PR DESCRIPTION
声明了全局的const = pivotTable；在函数内部，redo["pivotTable"] = pivotTable;  和 let pivotTable = _this.getPivotTableData(); 这两句会导致代码报错