### PR TITLE
feat(config) : 默认的新增行数目作为配置项

### DIFF
--- a/docs/zh/guide/config.md
+++ b/docs/zh/guide/config.md
@@ -60,6 +60,7 @@ Luckysheet开放了更细致的自定义配置选项，分别有
 - 底部计数栏 [showstatisticBar](#showstatisticBar)
 - 自定义计数栏 [showstatisticBarConfig](#showstatisticBarConfig)
 - 允许添加行 [enableAddRow](#enableAddRow)
+- 默认添加行的数目 [addRowCount](#addRowCount)
 - 允许回到顶部 [enableAddBackTop](#enableAddBackTop)
 - 用户信息 [userInfo](#userInfo)
 - 用户信息菜单 [userMenuItem](#userMenuItem)
@@ -468,6 +469,11 @@ Luckysheet开放了更细致的自定义配置选项，分别有
 - 类型：Boolean
 - 默认值：true
 - 作用：允许添加行
+
+### addRowCount
+- Number
+- 默认值：100
+- 作用：配置新增行处默认新增的行数目
 
 ------------
 ### enableAddBackTop

--- a/src/controllers/handler.js
+++ b/src/controllers/handler.js
@@ -4511,8 +4511,8 @@ export default function luckysheetHandler() {
 
         let $t = $(this), value = $("#luckysheet-bottom-add-row-input").val();
 
-        if (value == "") {
-            value = 100;
+        if (value == "") {            
+            value = luckysheetConfigsetting.addRowCount || 100;
         }
 
         if (isNaN(parseInt(value))) {

--- a/src/controllers/luckysheetConfigsetting.js
+++ b/src/controllers/luckysheetConfigsetting.js
@@ -19,6 +19,7 @@ const luckysheetConfigsetting = {
 
     showConfigWindowResize: true,
     enableAddRow: true,
+    addRowCount: 100,
     enableAddBackTop: true,
     enablePage: true,
     pageInfo: null,

--- a/src/core.js
+++ b/src/core.js
@@ -116,6 +116,7 @@ luckysheet.create = function (setting) {
     luckysheetConfigsetting.showConfigWindowResize = extendsetting.showConfigWindowResize;
     luckysheetConfigsetting.enableAddRow = extendsetting.enableAddRow;
     luckysheetConfigsetting.enableAddBackTop = extendsetting.enableAddBackTop;
+    luckysheetConfigsetting.addRowCount = extendsetting.addRowCount;
     luckysheetConfigsetting.enablePage = extendsetting.enablePage;
     luckysheetConfigsetting.pageInfo = extendsetting.pageInfo;
 

--- a/src/global/createdom.js
+++ b/src/global/createdom.js
@@ -61,7 +61,7 @@ export default function luckysheetcreatedom(colwidth, rowheight, data, menu, tit
     const _locale = locale();
     const locale_info = _locale.info;
 
-    let addControll = '<button id="luckysheet-bottom-add-row" class="btn btn-default">'+locale_info.add+'</button><input id="luckysheet-bottom-add-row-input" type="text" class="luckysheet-datavisual-config-input luckysheet-mousedown-cancel" placeholder="100"><span style="font-size: 14px;">'+ locale_info.row +'</span><span style="font-size: 14px;color: #9c9c9c;">('+locale_info.addLast+')</span>';
+    let addControll = '<button id="luckysheet-bottom-add-row" class="btn btn-default">'+locale_info.add+'</button><input id="luckysheet-bottom-add-row-input" type="text" class="luckysheet-datavisual-config-input luckysheet-mousedown-cancel" placeholder="'+(luckysheetConfigsetting.addRowCount || 100)+'"><span style="font-size: 14px;">'+ locale_info.row +'</span><span style="font-size: 14px;color: #9c9c9c;">('+locale_info.addLast+')</span>';
     let backControll = ' <button id="luckysheet-bottom-bottom-top" class="btn btn-default" style="">'+ locale_info.backTop +'</button>';
     // let pageControll = ' <span id="luckysheet-bottom-page-info" style="font-size: 14px;color: #f34141;">共'+ luckysheetConfigsetting.pageInfo.totalPage +'页，当前已显示'+ (luckysheetConfigsetting.pageInfo.currentPage) +'页，每页'+ luckysheetConfigsetting.pageInfo.pageSize +'条</span> <button id="luckysheet-bottom-page-next" class="btn btn-danger" style="">下一页</button>';
     let pageInfo = replaceHtml(locale_info.pageInfo,{


### PR DESCRIPTION
新增 `addRowCount` 配置项

```js
var options = {
    container: 'sheet', //luckysheet为容器id
    // 自定义默认新增行的数目
    addRowCount: 10
};
luckysheet.create(options);
```

可修改如下位置默认新增的行数目

![image](https://user-images.githubusercontent.com/13060680/129160283-d815fbe8-c10c-45f4-ad9c-9a14662302eb.png)
