### PR TITLE
fix: 修复初始config为空的清空下，粘贴后撤销，边距等信息未正确撤销的问题

### DIFF
--- a/src/global/refresh.js
+++ b/src/global/refresh.js
@@ -120,8 +120,8 @@ function jfrefreshgrid(data, range, allParam, isRunExecFunction = true, isRefres
     editor.webWorkerFlowDataCache(Store.flowdata);//worker存数据
     file.data = Store.flowdata;
 
-    //config, null or empty object are not processed
-    if(cfg != null  && Object.keys(cfg).length !== 0){
+    // 必须要处理，可能之前的config为空，则也需要清空
+    if(cfg != null){
         Store.config = cfg;
         file.config = Store.config;
 


### PR DESCRIPTION
RT, 就改了一行代码，可看下是否有问题。

#823 

之前：
![2021-11-04](https://user-images.githubusercontent.com/13060680/140288638-46c20661-bd60-43b1-88f8-08f4adcaf9fa.gif)
新的效果
![2021-11-04-2](https://user-images.githubusercontent.com/13060680/140288666-ee50bd83-4279-4cf6-9a74-2155a46adad8.gif)

 