### PR TITLE
fix: 修复添加sheet时，接受OP方的sheet滚动按钮显示问题

### DIFF
--- a/src/controllers/server.js
+++ b/src/controllers/server.js
@@ -825,6 +825,9 @@ const server = {
 
 	        $("#luckysheet-sheet-container-c").append(replaceHtml(sheetHTML, { "index": value.index, "active": "", "name": value.name, "style": "", "colorset": colorset }));
 	        $("#luckysheet-cell-main").append('<div id="luckysheet-datavisual-selection-set-' + value.index + '" class="luckysheet-datavisual-selection-set"></div>');
+
+					// *让接受OP方判断添加sheet后是否要出现sheet滚动按钮.
+					sheetmanage.locationSheet()
 	    }
 	    else if(type == "shc"){ //复制sheet
 	        let copyindex = value.copyindex, name = value.name;


### PR DESCRIPTION
#827 

**问题描述：**
A用户不断添加sheet，直到出现sheet滚动按钮，而B用户不断收到ws转发的添加sheet的OP，但是B用户处理OP添加完sheet后不会出现滚动按钮，即使已经超出了屏幕宽度的70%而被截断了

**问题原因：**
其余用户收到ws广播的添加sheet的OP时，做的处理没有去对是否显示滚动按钮做判断

**解决方案：**
在server.js文件处理新建sheet的OP结束后，调用sheetmanage.locationSheet()，计算是否显示滚动按钮

**之前效果：**
![buggif](https://user-images.githubusercontent.com/46434433/141050459-5d43143f-9652-473a-9b94-861309251b25.gif)

**改之后效果：**
![修改后效果图](https://user-images.githubusercontent.com/46434433/141050508-1872de11-5712-4b60-adb9-1dd94d3eb91d.gif)
