### PR TITLE
fix: 修复添加sheet后的数据丢失问题.

### DIFF
--- a/src/controllers/sheetmanage.js
+++ b/src/controllers/sheetmanage.js
@@ -1241,7 +1241,10 @@ const sheetmanage = {
                 file["data"] = data;
                 file["load"] = "1";
 
-                _this.loadOtherFile(file);
+                // *这里不应该调用loadOtherFile去加载其余页面的数据,
+                // *因为loadOtherFile里判断后会调用buildGridData把其余的sheet的数据设置为空的二维数组,即使那个sheet在服务端存在数据.
+                // *这就导致一个数据丢失问题.
+                // _this.loadOtherFile(file);
 
                 // let sheetindexset = _this.checkLoadSheetIndex(file);
                 // let sheetindex = [];


### PR DESCRIPTION
#832

**问题描述：**
1. 服务端已有sheet1、sheet2两张表，且都有数据。
2. A、B都是刚进入的状态，只打开了sheet1。
3. A打开sheet2显示正常且有数据。
4. B新增一个sheet后，再打开sheet2，发现没有从服务端拉数据

**问题原因：**
B用户新增sheet，初始化新增的这个sheet的数据之后，会去加载所有未加载的sheet数据。但是调用loadOtherFile方法最后走到了getdata.js里的datagridgrowth方法里面去初始化数据而没有从服务端拉。初始化后的数据就跟服务端存的数据不同了。

**解决方案：**
注释sheetmanage.js里changeSheet方法里的loadOtherFile，不调用即可。没有必要把其余未加载的sheet的数据全都加载出来（更何况loadOtherFile的加载最后是把初始化用的数据写入进去）

**之前效果：**
![修改前问题](https://user-images.githubusercontent.com/46434433/141076924-7f9579e6-d5f1-41c8-9b4f-1ace1e3d17e6.gif)


**改之后效果：**
![修改后效果](https://user-images.githubusercontent.com/46434433/141076934-4e8e91bb-2817-46a1-8e2d-438aee7f592f.gif)