### PR TITLE
fix: 修复重命名sheet为空时的tooltipbug，修改重命名的交互。

### DIFF
--- a/src/controllers/sheetBar.js
+++ b/src/controllers/sheetBar.js
@@ -271,20 +271,15 @@ export function initialSheetBar(){
             return;
         }
 
+        let $t = $(this);
+        let txt = $t.text(), oldtxt = $t.data("oldtxt");
+
         if(0 === $(this).text().length){
-
             tooltip.info("", locale_sheetconfig.sheetNamecannotIsEmptyError);
-
-            setTimeout(()=>{
-                $(this).text(oldSheetFileName);
-                luckysheetsheetnameeditor($(this));
-                $(this).focus();
-            }, 1);
+            $t.text(oldtxt).attr("contenteditable", "false");
             return;
         }
 
-        let $t = $(this);
-        let txt = $t.text(), oldtxt = $t.data("oldtxt");
         if(txt.length>31 || txt.charAt(0)=="'" || txt.charAt(txt.length-1)=="'" || /[：\:\\\/？\?\*\[\]]+/.test(txt)){
             alert(locale_sheetconfig.sheetNameSpecCharError);
             setTimeout(()=>{

--- a/src/controllers/sheetBar.js
+++ b/src/controllers/sheetBar.js
@@ -281,11 +281,8 @@ export function initialSheetBar(){
         }
 
         if(txt.length>31 || txt.charAt(0)=="'" || txt.charAt(txt.length-1)=="'" || /[：\:\\\/？\?\*\[\]]+/.test(txt)){
-            alert(locale_sheetconfig.sheetNameSpecCharError);
-            setTimeout(()=>{
-                luckysheetsheetnameeditor($(this));
-                $(this).focus();
-            }, 1);
+            tooltip.info("", locale_sheetconfig.sheetNameSpecCharError);
+            $t.text(oldtxt).attr("contenteditable", "false");
             return;
         }
 


### PR DESCRIPTION
#835 

**问题描述：**
重命名sheet为空时弹出tooltip提示，会导致阻止无法关闭，阻止任意下一步

**问题原因：**
重命名校验这里的交互，当判断输入是空时，会弹出tooltip提示并focus重命名的输入框，这时候点击tooltip的关闭或者任意地方就又会触发blur失焦事件再次tooltip，所以阻止了任意的下一步操作。

**解决方案：**
修改交互为，判断输入的不符合规则，tooltip提示错误类型，并充值sheet名称为原本的值，并关闭输入框。目前业界内的在线表格都是这样做的。

**之前效果：**
![修改前问题](https://user-images.githubusercontent.com/46434433/141089626-2b8cfe0d-d9b6-4240-929a-7ec567f8bdae.gif)


**改之后效果：**
![修改后效果](https://user-images.githubusercontent.com/46434433/141089634-a86d5c4d-f6ff-4f69-a89a-b991e712d083.gif)
