### PR TITLE
fix: 修复隐藏和删除sheet时，右下角的滚动按钮不会重新计算的问题

### DIFF
--- a/src/controllers/server.js
+++ b/src/controllers/server.js
@@ -879,6 +879,7 @@ const server = {
 
 	        $("#luckysheet-sheets-item" + value.deleIndex).remove();
 			$("#luckysheet-datavisual-selection-set-" + value.deleIndex).remove();
+			sheetmanage.locationSheet()
 
 	    }
 	    else if(type == "shr"){ //sheet位置
@@ -920,6 +921,7 @@ const server = {
 	            file.hide = 0;
 	            $("#luckysheet-sheets-item" + index).show();
 	        }
+				sheetmanage.locationSheet()
 	    }
 	    else if(type == "c"){ //图表操作 TODO
 	        let op = item.op, cid = item.cid;

--- a/src/controllers/sheetmanage.js
+++ b/src/controllers/sheetmanage.js
@@ -319,6 +319,7 @@ const sheetmanage = {
         $("#luckysheet-sheets-item" + indicator).addClass("luckysheet-sheets-item-active");
         
         _this.changeSheetExec(indicator);
+        _this.locationSheet();
 
         server.saveParam("sh", luckysheetcurrentSheetitem.data("index"), 1, { "op": "hide", "cur": indicator });
         // 钩子 sheetHideAfter
@@ -438,6 +439,7 @@ const sheetmanage = {
 
         _this.locationSheet();
     },
+    // *控制sheet栏的左右滚动按钮是否显示
     locationSheet: function() {
         let $c = $("#luckysheet-sheet-container-c"), winW = $("#"+Store.container).width();
         let $cursheet = $("#luckysheet-sheet-container-c > div.luckysheet-sheets-item-active").eq(0);
@@ -455,13 +457,16 @@ const sheetmanage = {
         setTimeout(function(){
             $c.scrollLeft(scrollLeftpx - 10);
 
-            if (c_width >= winW * 0.7) {
-                if(luckysheetConfigsetting.showsheetbarConfig.sheet){
+            if (luckysheetConfigsetting.showsheetbarConfig.sheet){
+                if (c_width >= winW * 0.7) {
                     $("#luckysheet-sheet-area .luckysheet-sheets-scroll").css("display", "inline-block");
                     $("#luckysheet-sheet-container .docs-sheet-fade-left").show();
+                } else {
+                    $("#luckysheet-sheet-area .luckysheet-sheets-scroll").css("display", "none");
+                    $("#luckysheet-sheet-container .docs-sheet-fade-left").hide();
                 }
-                
             }
+
         }, 1)
     },
     copySheet: function(copyindex, e) {
@@ -1550,6 +1555,7 @@ const sheetmanage = {
             $("#luckysheet-sheet-container .docs-sheet-fade-left").hide();
         }
     },
+    // *显示sheet栏左右的灰色
     sheetBarShowAndHide(index){
         let $c = $("#luckysheet-sheet-container-c");
 


### PR DESCRIPTION
#838 

**问题描述：**
1. 添加sheet直到右下角出现滚动按钮
2. 删除sheet（或者隐藏sheet）
3. 可以发现滚动按钮会一直存在，即使最后删除到只剩一个sheet

PS：协同情况下，上述操作对于其余接收OP的用户也是一样没有判断滚动按钮。


**问题原因：**
删除sheet的逻辑，先要走一次sheet隐藏的setSheetHide方法，而在这个方法中，没有对隐藏sheet之后的sheet栏滚动按钮是否显示做处理。


**解决方案：**
setSheetHide方法处理完后，加入locationSheet方法判断是否显示，并修改locationSheet方法的判断，当sheet栏的占宽不宽于屏幕宽的70%时，隐藏滚动按钮。


**删除sheet截图gif：**
![修改前问题（删除）](https://user-images.githubusercontent.com/46434433/141253132-29301f73-7844-42fc-9815-c34eaad37984.gif)

**隐藏sheet截图gif：**
![修改前问题（隐藏）](https://user-images.githubusercontent.com/46434433/141253129-be136a1d-a560-456d-a052-b8391f6f489c.gif)

**修改后效果：**
![修改后效果](https://user-images.githubusercontent.com/46434433/141253562-895d6fe7-5761-4b50-8040-567fba91a04e.gif)
