### PR TITLE
fix: 修复协同编辑情况下的重命名sheet后OP广播错误问题

### DIFF
--- a/src/controllers/sheetBar.js
+++ b/src/controllers/sheetBar.js
@@ -174,10 +174,12 @@ export function initialSheetBar(){
         let $t = $(this), $cur = $(e.target), $item = $cur.closest(".luckysheet-sheets-item");
 
         if (e.which == "3") {
-            luckysheetsheetrightclick($t, $cur, e);
-            luckysheetcurrentSheetitem = $item;
-            showsheetconfigmenu();
-            return;
+            setTimeout(() => {
+                luckysheetsheetrightclick($t, $cur, e);
+                luckysheetcurrentSheetitem = $item;
+                showsheetconfigmenu();
+                return;
+            }, 0);
         }
 
         if ($item.hasClass("luckysheet-sheets-item-active") && $item.find(".luckysheet-sheets-item-name").attr("contenteditable") == "false") {


### PR DESCRIPTION
#840 

**问题描述：**
协同编辑，点击重命名，出现input框，输入后还未失焦保存。
右键其余的sheet，触发失焦和sheet的右击事件。
会发现其余接收到OP的用户，重命名的sheet和实际不符

**问题原因：**
重命名sheet时，会去取Store.currentSheetIndex的值作为OP里的值，而我们右键点击了sheet后触发了mousedown事件，会切换当前使用的sheet（改变了Store.currentSheetIndex），而mousedown事件触发的又比blur事件早，所以广播给其他用户的值就会有问题。

**解决方案：**
改变mousedown和blur的触发顺序


**修改前效果**：
![修改前问题](https://user-images.githubusercontent.com/46434433/141404733-0575a93a-29b4-4a4c-9d82-3cdd68d530eb.gif)


**修改后效果：**
![修改后效果](https://user-images.githubusercontent.com/46434433/141404739-2cb96d5f-433b-442d-9ca2-374c46842258.gif)

