### PR TITLE
feat: 修改协同编辑的光标提示，hover上去显示完整用户名

### DIFF
--- a/src/controllers/server.js
+++ b/src/controllers/server.js
@@ -970,6 +970,7 @@ const server = {
     multipleIndex: 0,
     multipleRangeShow: function(id, name, r, c, value) {
     	let _this = this;
+			const fullName = name;
 
 	    let row = Store.visibledatarow[r],
 	        row_pre = r - 1 == -1 ? 0 : Store.visibledatarow[r - 1],
@@ -1021,7 +1022,7 @@ const server = {
 								id="luckysheet-multipleRange-show-${id}"
 								class="luckysheet-multipleRange-show"
 								data-color="${luckyColor[_this.multipleIndex]}"
-								title="${name}"
+								title="${fullName}"
 								style="position: absolute;left: ${col_pre - 1}px;width: ${col - col_pre - 1}px;top: ${row_pre - 1}px;height: ${row - row_pre - 1}px;border: 1px solid ${luckyColor[_this.multipleIndex]};z-index: 15;">
 
 								<div class="username" style="height: 19px;line-height:19px;width: max-content;position: absolute;bottom: ${row - row_pre - 1}px;right: 0;background-color: ${luckyColor[_this.multipleIndex]};color:#ffffff;padding:0 10px;">


### PR DESCRIPTION

正常来说，协同编辑情况下，光标同步后的用户名，hover上去显示的用户名应该是完整的用户名。

**之前：**
![修改前问题](https://user-images.githubusercontent.com/46434433/141423911-5f89f6dc-9145-4222-89a4-8ea4fe6cdd05.gif)

现在：****
![修改后效果](https://user-images.githubusercontent.com/46434433/141423915-a7a6f807-1f3c-47ed-ad3d-483724945df1.gif)
