### PR TITLE
修复冻结首行实际是冻结了当前视图的第一行的问题

### DIFF
--- a/src/controllers/freezen.js
+++ b/src/controllers/freezen.js
@@ -49,6 +49,26 @@ const luckysheetFreezen = {
 
         const _locale = locale();
         const locale_freezen = _locale.freezen;
+        // 解决freeze 不垂直居中的问题
+        const freezeHTML = `
+            <div class="luckysheet-toolbar-button-outer-box luckysheet-inline-block"
+            style="user-select: none;">
+                <div class="luckysheet-toolbar-button-inner-box luckysheet-inline-block"
+                style="user-select: none;">
+                    <div class="luckysheet-icon luckysheet-inline-block " style="user-select: none;">
+                        <div aria-hidden="true" class="luckysheet-icon-img-container luckysheet-icon-img luckysheet-icon-function iconfont luckysheet-iconfont-dongjie1"
+                        style="user-select: none;">
+                        </div>
+                    </div>
+                    <div class="luckysheet-toolbar-menu-button-caption luckysheet-inline-block"
+                    style="user-select: none;">
+                        ${locale_freezen.default}
+                    </div>
+                </div>
+            </div>
+        `
+
+        $("#luckysheet-freezen-btn-horizontal").html(freezeHTML);
 
         $("#luckysheet-freezen-btn-vertical").html('<i class="fa fa-indent"></i> '+locale_freezen.freezenColumn);
         _this.freezenverticaldata = null;

--- a/src/controllers/freezen.js
+++ b/src/controllers/freezen.js
@@ -9,6 +9,8 @@ import luckysheetDropCell from './dropCell';
 import { rowLocationByIndex, colLocationByIndex } from '../global/location';
 import Store from '../store';
 import locale from '../locale/locale';
+import { luckysheetrefreshgrid } from '../global/refresh';
+
 
 const luckysheetFreezen = {
     freezenHorizontalHTML: '<div id="luckysheet-freezebar-horizontal" class="luckysheet-freezebar" tabindex="0"><div class="luckysheet-freezebar-handle luckysheet-freezebar-horizontal-handle" ><div class="luckysheet-freezebar-handle-bar luckysheet-freezebar-horizontal-handle-title" ></div><div class="luckysheet-freezebar-handle-bar luckysheet-freezebar-horizontal-handle-bar" ></div></div><div class="luckysheet-freezebar-drop luckysheet-freezebar-horizontal-drop" ><div class="luckysheet-freezebar-drop-bar luckysheet-freezebar-horizontal-drop-title" ></div><div class="luckysheet-freezebar-drop-bar luckysheet-freezebar-horizontal-drop-bar" >&nbsp;</div></div></div>',
@@ -370,24 +372,34 @@ const luckysheetFreezen = {
         }
 
         if (freezenhorizontaldata == null) {
-            let scrollTop = $("#luckysheet-cell-main").scrollTop();
-            let dataset_row_st = luckysheet_searcharray(Store.visibledatarow, scrollTop);
-            if (dataset_row_st == -1) {
-                dataset_row_st = 0;
-            }
+            // let scrollTop = $("#luckysheet-cell-main").scrollTop();
+            // let dataset_row_st = luckysheet_searcharray(Store.visibledatarow, scrollTop);
+            // if (dataset_row_st == -1) {
+            //     dataset_row_st = 0;
+            // }
+            dataset_row_st = 0;
 
-            top = Store.visibledatarow[dataset_row_st] - 2 - scrollTop + Store.columnHeaderHeight;
+            // top = Store.visibledatarow[dataset_row_st] - 2 - scrollTop + Store.columnHeaderHeight;
+            top = Store.visibledatarow[dataset_row_st] - 2 + Store.columnHeaderHeight;
             freezenhorizontaldata = [
                 Store.visibledatarow[dataset_row_st], 
                 dataset_row_st + 1, 
-                scrollTop, 
+                0, 
                 _this.cutVolumn(Store.visibledatarow, dataset_row_st + 1), 
                 top
             ];
             _this.saveFreezen(freezenhorizontaldata, top, null, null);
+            // todo: 没有下面代码 如果有滚动，冻结之后首行的行号仍显示的之前滚动的行号
+            // todo: 不 setTimeout 这里直接刷新的话，冻结的首行显示有问题，没有列的分割线
+            setTimeout(() => {
+                luckysheetFreezen.createAssistCanvas();
+                luckysheetrefreshgrid();
+            });
         }
 
         _this.freezenhorizontaldata = freezenhorizontaldata;
+        
+
 
         // $("#luckysheet-freezen-btn-horizontal").html('<i class="fa fa-list-alt"></i> '+locale().freezen.freezenCancel);
 
@@ -414,6 +426,7 @@ const luckysheetFreezen = {
         $("#luckysheet-freezen-btn-horizontal").html(freezeHTML);
 
         $("#luckysheet-freezebar-horizontal").show().find(".luckysheet-freezebar-horizontal-handle").css({ "top": top }).end().find(".luckysheet-freezebar-horizontal-drop").css({ "top": top });
+
     },
     createAssistCanvas: function(){
         let _this = this;

--- a/src/controllers/handler.js
+++ b/src/controllers/handler.js
@@ -4956,6 +4956,8 @@ export default function luckysheetHandler() {
             }
 
             luckysheetFreezen.scrollAdapt();
+            // cancel 之后 勾勾取消
+            $('#luckysheet-icon-freezen-menu-menuButton').find('.fa.fa-check').remove();
         }
         else {
 

--- a/src/controllers/menuButton.js
+++ b/src/controllers/menuButton.js
@@ -1619,7 +1619,7 @@ const menuButton = {
 
                     let $t = $(this), itemvalue = $t.attr("itemvalue");
                     _this.focus($menuButton, itemvalue);
-                    if (itemvalue === locale_freezen.freezenCancel) {
+                    if (itemvalue === 'freezenCancel') {
                         $menuButton.find('.fa.fa-check').remove();
                     }
 

--- a/src/controllers/menuButton.js
+++ b/src/controllers/menuButton.js
@@ -1710,6 +1710,7 @@ const menuButton = {
                         luckysheetrefreshgrid();
                     }
                     else if(itemvalue == "freezenRowRange"){ //选区行冻结
+
                         if(Store.luckysheet_select_save == null || Store.luckysheet_select_save.length == 0){
                             if(isEditMode()){
                                 alert(locale_freezen.noSeletionError);
@@ -1720,7 +1721,11 @@ const menuButton = {
 
                             return;
                         }
-                        
+                        // 固定超出屏幕范围
+                        let rangeTop = Store.luckysheet_select_save[Store.luckysheet_select_save.length - 1].top;
+                        if (luckysheetFreezen.freezenRealFirstRowColumn && rangeTop > $("#luckysheet-cell-main").height()) {
+                            return  tooltip.info(locale_freezen.rangeRCOverErrorTitle, locale_freezen.rangeRCOverError);
+                        }
                         let scrollTop = $("#luckysheet-cell-main").scrollTop();
                         let row_st = luckysheet_searcharray(Store.visibledatarow, scrollTop);
 
@@ -1760,7 +1765,11 @@ const menuButton = {
 
                             return;
                         }
-                        
+                        // 固定超出屏幕范围
+                        let rangeLeft = Store.luckysheet_select_save[Store.luckysheet_select_save.length - 1].left;
+                        if (luckysheetFreezen.freezenRealFirstRowColumn && rangeLeft > $("#luckysheet-cell-main").width()) {
+                            return  tooltip.info(locale_freezen.rangeRCOverErrorTitle, locale_freezen.rangeRCOverError);
+                        }
                         let scrollLeft = $("#luckysheet-cell-main").scrollLeft();
                         let col_st = luckysheet_searcharray(Store.visibledatacolumn, scrollLeft);
 
@@ -1799,6 +1808,13 @@ const menuButton = {
                             }
 
                             return;
+                        }
+
+                        // 固定超出屏幕范围
+                        let rangeTop = Store.luckysheet_select_save[Store.luckysheet_select_save.length - 1].top;
+                        let rangeLeft = Store.luckysheet_select_save[Store.luckysheet_select_save.length - 1].left;
+                        if (luckysheetFreezen.freezenRealFirstRowColumn && (rangeTop > $("#luckysheet-cell-main").height() || rangeLeft > $("#luckysheet-cell-main").width())) {
+                            return  tooltip.info(locale_freezen.rangeRCOverErrorTitle, locale_freezen.rangeRCOverError);
                         }
                         
                         let scrollTop = $("#luckysheet-cell-main").scrollTop();

--- a/src/controllers/menuButton.js
+++ b/src/controllers/menuButton.js
@@ -1666,28 +1666,43 @@ const menuButton = {
                         // luckysheetrefreshgrid();
                     }
                     else if(itemvalue == "freezenRC"){ //首行列冻结
-                        let scrollTop = $("#luckysheet-cell-main").scrollTop();
-                        let row_st = luckysheet_searcharray(Store.visibledatarow, scrollTop);
-                        if(row_st == -1){
-                            row_st = 0;
+                        if (luckysheetFreezen.freezenRealFirstRowColumn) {
+                            let row_st = 0;
+                            let top = Store.visibledatarow[row_st] - 2 + Store.columnHeaderHeight;
+                            let freezenhorizontaldata = [Store.visibledatarow[row_st], row_st + 1, 0, luckysheetFreezen.cutVolumn(Store.visibledatarow, row_st + 1), top];
+                            luckysheetFreezen.saveFreezen(freezenhorizontaldata, top, null, null);
+
+                            luckysheetFreezen.createFreezenHorizontal(freezenhorizontaldata, top);
+
+                            let col_st = 0;
+                            let left = Store.visibledatacolumn[col_st] - 2 + Store.rowHeaderWidth;
+                            let freezenverticaldata = [Store.visibledatacolumn[col_st], col_st + 1, 0, luckysheetFreezen.cutVolumn(Store.visibledatacolumn, col_st + 1), left];
+                            luckysheetFreezen.saveFreezen(null, null, freezenverticaldata, left);
+
+                            luckysheetFreezen.createFreezenVertical(freezenverticaldata, left);
+                        } else {
+                            let scrollTop = $("#luckysheet-cell-main").scrollTop();
+                            let row_st = luckysheet_searcharray(Store.visibledatarow, scrollTop);
+                            if(row_st == -1){
+                                row_st = 0;
+                            }
+                            let top = Store.visibledatarow[row_st] - 2 - scrollTop + Store.columnHeaderHeight;
+                            let freezenhorizontaldata = [Store.visibledatarow[row_st], row_st + 1, scrollTop, luckysheetFreezen.cutVolumn(Store.visibledatarow, row_st + 1), top];
+                            luckysheetFreezen.saveFreezen(freezenhorizontaldata, top, null, null);
+
+                            luckysheetFreezen.createFreezenHorizontal(freezenhorizontaldata, top);
+
+                            let scrollLeft = $("#luckysheet-cell-main").scrollLeft();
+                            let col_st = luckysheet_searcharray(Store.visibledatacolumn, scrollLeft);
+                            if(col_st == -1){
+                                col_st = 0;
+                            }
+                            let left = Store.visibledatacolumn[col_st] - 2 - scrollLeft + Store.rowHeaderWidth;
+                            let freezenverticaldata = [Store.visibledatacolumn[col_st], col_st + 1, scrollLeft, luckysheetFreezen.cutVolumn(Store.visibledatacolumn, col_st + 1), left];
+                            luckysheetFreezen.saveFreezen(null, null, freezenverticaldata, left);
+
+                            luckysheetFreezen.createFreezenVertical(freezenverticaldata, left);
                         }
-                        let top = Store.visibledatarow[row_st] - 2 - scrollTop + Store.columnHeaderHeight;
-                        let freezenhorizontaldata = [Store.visibledatarow[row_st], row_st + 1, scrollTop, luckysheetFreezen.cutVolumn(Store.visibledatarow, row_st + 1), top];
-                        luckysheetFreezen.saveFreezen(freezenhorizontaldata, top, null, null);
-
-                        luckysheetFreezen.createFreezenHorizontal(freezenhorizontaldata, top);
-
-                        let scrollLeft = $("#luckysheet-cell-main").scrollLeft();
-                        let col_st = luckysheet_searcharray(Store.visibledatacolumn, scrollLeft);
-                        if(col_st == -1){
-                            col_st = 0;
-                        }
-                        let left = Store.visibledatacolumn[col_st] - 2 - scrollLeft + Store.rowHeaderWidth;
-                        let freezenverticaldata = [Store.visibledatacolumn[col_st], col_st + 1, scrollLeft, luckysheetFreezen.cutVolumn(Store.visibledatacolumn, col_st + 1), left];
-                        luckysheetFreezen.saveFreezen(null, null, freezenverticaldata, left);
-
-                        luckysheetFreezen.createFreezenVertical(freezenverticaldata, left);
-
                         luckysheetFreezen.createAssistCanvas();
                         luckysheetrefreshgrid();
                     }

--- a/src/controllers/menuButton.js
+++ b/src/controllers/menuButton.js
@@ -1619,6 +1619,9 @@ const menuButton = {
 
                     let $t = $(this), itemvalue = $t.attr("itemvalue");
                     _this.focus($menuButton, itemvalue);
+                    if (itemvalue === locale_freezen.freezenCancel) {
+                        $menuButton.find('.fa.fa-check').remove();
+                    }
 
                     // store frozen
                     luckysheetFreezen.saveFrozen(itemvalue);

--- a/src/controllers/menuButton.js
+++ b/src/controllers/menuButton.js
@@ -37,7 +37,7 @@ import { replaceHtml, getObjType, rgbTohex, mouseclickposition, luckysheetfontfo
 import {openProtectionModal,checkProtectionFormatCells,checkProtectionNotEnable} from './protection';
 import Store from '../store';
 import locale from '../locale/locale';
-import {checkTheStatusOfTheSelectedCells, frozenFirstRow} from '../global/api';
+import { checkTheStatusOfTheSelectedCells, frozenFirstRow, frozenFirstColumn } from '../global/api';
 
 const menuButton = {
     "menu": '<div class="luckysheet-cols-menu luckysheet-rightgclick-menu luckysheet-menuButton ${subclass} luckysheet-mousedown-cancel" id="luckysheet-icon-${id}-menuButton">${item}</div>',
@@ -1645,24 +1645,25 @@ const menuButton = {
                         // luckysheetrefreshgrid();
                     }
                     else if(itemvalue == "freezenColumn"){ //首列冻结
-                        let scrollLeft = $("#luckysheet-cell-main").scrollLeft();
-                        let col_st = luckysheet_searcharray(Store.visibledatacolumn, scrollLeft);
-                        if(col_st == -1){
-                            col_st = 0;
-                        }
-                        let left = Store.visibledatacolumn[col_st] - 2 - scrollLeft + Store.rowHeaderWidth;
-                        let freezenverticaldata = [Store.visibledatacolumn[col_st], col_st + 1, scrollLeft, luckysheetFreezen.cutVolumn(Store.visibledatacolumn, col_st + 1), left];
-                        luckysheetFreezen.saveFreezen(null, null, freezenverticaldata, left);
+                        frozenFirstColumn();
+                        // let scrollLeft = $("#luckysheet-cell-main").scrollLeft();
+                        // let col_st = luckysheet_searcharray(Store.visibledatacolumn, scrollLeft);
+                        // if(col_st == -1){
+                        //     col_st = 0;
+                        // }
+                        // let left = Store.visibledatacolumn[col_st] - 2 - scrollLeft + Store.rowHeaderWidth;
+                        // let freezenverticaldata = [Store.visibledatacolumn[col_st], col_st + 1, scrollLeft, luckysheetFreezen.cutVolumn(Store.visibledatacolumn, col_st + 1), left];
+                        // luckysheetFreezen.saveFreezen(null, null, freezenverticaldata, left);
 
-                        if (luckysheetFreezen.freezenhorizontaldata != null) {
-                            luckysheetFreezen.cancelFreezenHorizontal();
-                            luckysheetFreezen.createAssistCanvas();
-                            luckysheetrefreshgrid();
-                        }
+                        // if (luckysheetFreezen.freezenhorizontaldata != null) {
+                        //     luckysheetFreezen.cancelFreezenHorizontal();
+                        //     luckysheetFreezen.createAssistCanvas();
+                        //     luckysheetrefreshgrid();
+                        // }
 
-                        luckysheetFreezen.createFreezenVertical(freezenverticaldata, left);
-                        luckysheetFreezen.createAssistCanvas();
-                        luckysheetrefreshgrid();
+                        // luckysheetFreezen.createFreezenVertical(freezenverticaldata, left);
+                        // luckysheetFreezen.createAssistCanvas();
+                        // luckysheetrefreshgrid();
                     }
                     else if(itemvalue == "freezenRC"){ //首行列冻结
                         let scrollTop = $("#luckysheet-cell-main").scrollTop();

--- a/src/controllers/menuButton.js
+++ b/src/controllers/menuButton.js
@@ -37,7 +37,7 @@ import { replaceHtml, getObjType, rgbTohex, mouseclickposition, luckysheetfontfo
 import {openProtectionModal,checkProtectionFormatCells,checkProtectionNotEnable} from './protection';
 import Store from '../store';
 import locale from '../locale/locale';
-import {checkTheStatusOfTheSelectedCells} from '../global/api';
+import {checkTheStatusOfTheSelectedCells, frozenFirstRow} from '../global/api';
 
 const menuButton = {
     "menu": '<div class="luckysheet-cols-menu luckysheet-rightgclick-menu luckysheet-menuButton ${subclass} luckysheet-mousedown-cancel" id="luckysheet-icon-${id}-menuButton">${item}</div>',
@@ -1624,24 +1624,25 @@ const menuButton = {
                     luckysheetFreezen.saveFrozen(itemvalue);
 
                     if(itemvalue == "freezenRow"){ //首行冻结
-                        let scrollTop = $("#luckysheet-cell-main").scrollTop();
-                        let row_st = luckysheet_searcharray(Store.visibledatarow, scrollTop);
-                        if(row_st == -1){
-                            row_st = 0;
-                        }
-                        let top = Store.visibledatarow[row_st] - 2 - scrollTop + Store.columnHeaderHeight;
-                        let freezenhorizontaldata = [Store.visibledatarow[row_st], row_st + 1, scrollTop, luckysheetFreezen.cutVolumn(Store.visibledatarow, row_st + 1), top];
-                        luckysheetFreezen.saveFreezen(freezenhorizontaldata, top, null, null);
+                        frozenFirstRow();
+                        // let scrollTop = $("#luckysheet-cell-main").scrollTop();
+                        // let row_st = luckysheet_searcharray(Store.visibledatarow, scrollTop);
+                        // if(row_st == -1){
+                        //     row_st = 0;
+                        // }
+                        // let top = Store.visibledatarow[row_st] - 2 - scrollTop + Store.columnHeaderHeight;
+                        // let freezenhorizontaldata = [Store.visibledatarow[row_st], row_st + 1, scrollTop, luckysheetFreezen.cutVolumn(Store.visibledatarow, row_st + 1), top];
+                        // luckysheetFreezen.saveFreezen(freezenhorizontaldata, top, null, null);
 
-                        if (luckysheetFreezen.freezenverticaldata != null) {
-                            luckysheetFreezen.cancelFreezenVertical();
-                            luckysheetFreezen.createAssistCanvas();
-                            luckysheetrefreshgrid();
-                        }
+                        // if (luckysheetFreezen.freezenverticaldata != null) {
+                        //     luckysheetFreezen.cancelFreezenVertical();
+                        //     luckysheetFreezen.createAssistCanvas();
+                        //     luckysheetrefreshgrid();
+                        // }
 
-                        luckysheetFreezen.createFreezenHorizontal(freezenhorizontaldata, top);
-                        luckysheetFreezen.createAssistCanvas();
-                        luckysheetrefreshgrid();
+                        // luckysheetFreezen.createFreezenHorizontal(freezenhorizontaldata, top);
+                        // luckysheetFreezen.createAssistCanvas();
+                        // luckysheetrefreshgrid();
                     }
                     else if(itemvalue == "freezenColumn"){ //首列冻结
                         let scrollLeft = $("#luckysheet-cell-main").scrollLeft();

--- a/src/global/api.js
+++ b/src/global/api.js
@@ -609,18 +609,20 @@ export function frozenFirstRow(order) {
 
     // 冻结为当前sheet页
     if (!order || order == getSheetIndex(Store.currentSheetIndex)) {
-        let scrollTop = $("#luckysheet-cell-main").scrollTop();
+        // let scrollTop = $("#luckysheet-cell-main").scrollTop();
 
-        let row_st = luckysheet_searcharray(Store.visibledatarow, scrollTop);
-        if(row_st == -1){
-            row_st = 0;
-        }
-
-        let top = Store.visibledatarow[row_st] - 2 - scrollTop + Store.columnHeaderHeight;
+        // let row_st = luckysheet_searcharray(Store.visibledatarow, scrollTop);
+        // if(row_st == -1){
+        //     row_st = 0;
+        // }
+        let row_st = 0;
+        
+        // let top = Store.visibledatarow[row_st] - 2 - scrollTop + Store.columnHeaderHeight;
+        let top = Store.visibledatarow[row_st] - 2 + Store.columnHeaderHeight;
         let freezenhorizontaldata = [
             Store.visibledatarow[row_st],
             row_st + 1,
-            scrollTop,
+            0,
             luckysheetFreezen.cutVolumn(Store.visibledatarow, row_st + 1),
             top
         ];

--- a/src/global/api.js
+++ b/src/global/api.js
@@ -651,18 +651,20 @@ export function frozenFirstColumn(order) {
 
     // 冻结为当前sheet页
     if (!order || order == getSheetIndex(Store.currentSheetIndex)) {
-        let scrollLeft = $("#luckysheet-cell-main").scrollLeft();
+        // let scrollLeft = $("#luckysheet-cell-main").scrollLeft();
 
-        let col_st = luckysheet_searcharray(Store.visibledatacolumn, scrollLeft);
-        if(col_st == -1){
-            col_st = 0;
-        }
+        // let col_st = luckysheet_searcharray(Store.visibledatacolumn, scrollLeft);
+        // if(col_st == -1){
+        //     col_st = 0;
+        // }
+        let col_st = 0;
 
-        let left = Store.visibledatacolumn[col_st] - 2 - scrollLeft + Store.rowHeaderWidth;
+        // let left = Store.visibledatacolumn[col_st] - 2 - scrollLeft + Store.rowHeaderWidth;
+        let left = Store.visibledatacolumn[col_st] - 2 + Store.rowHeaderWidth;
         let freezenverticaldata = [
             Store.visibledatacolumn[col_st],
             col_st + 1,
-            scrollLeft,
+            0,
             luckysheetFreezen.cutVolumn(Store.visibledatacolumn, col_st + 1),
             left
         ];

--- a/src/global/api.js
+++ b/src/global/api.js
@@ -609,23 +609,34 @@ export function frozenFirstRow(order) {
 
     // 冻结为当前sheet页
     if (!order || order == getSheetIndex(Store.currentSheetIndex)) {
-        // let scrollTop = $("#luckysheet-cell-main").scrollTop();
+        let freezenhorizontaldata, row_st, top;
+        if (luckysheetFreezen.freezenRealFirstRowColumn) {
+            let row_st = 0;
+            top = Store.visibledatarow[row_st] - 2 + Store.columnHeaderHeight;
+            freezenhorizontaldata = [
+                Store.visibledatarow[row_st],
+                row_st + 1,
+                0,
+                luckysheetFreezen.cutVolumn(Store.visibledatarow, row_st + 1),
+                top
+            ];
+        } else {
+            let scrollTop = $("#luckysheet-cell-main").scrollTop();
+            row_st = luckysheet_searcharray(Store.visibledatarow, scrollTop);
+            if(row_st == -1){
+                row_st = 0;
+            }
 
-        // let row_st = luckysheet_searcharray(Store.visibledatarow, scrollTop);
-        // if(row_st == -1){
-        //     row_st = 0;
-        // }
-        let row_st = 0;
+            top = Store.visibledatarow[row_st] - 2 - scrollTop + Store.columnHeaderHeight;
+            freezenhorizontaldata = [
+                Store.visibledatarow[row_st],
+                row_st + 1,
+                scrollTop,
+                luckysheetFreezen.cutVolumn(Store.visibledatarow, row_st + 1),
+                top
+            ];
+        }
         
-        // let top = Store.visibledatarow[row_st] - 2 - scrollTop + Store.columnHeaderHeight;
-        let top = Store.visibledatarow[row_st] - 2 + Store.columnHeaderHeight;
-        let freezenhorizontaldata = [
-            Store.visibledatarow[row_st],
-            row_st + 1,
-            0,
-            luckysheetFreezen.cutVolumn(Store.visibledatarow, row_st + 1),
-            top
-        ];
         luckysheetFreezen.saveFreezen(freezenhorizontaldata, top, null, null);
 
         if (luckysheetFreezen.freezenverticaldata != null) {
@@ -651,23 +662,35 @@ export function frozenFirstColumn(order) {
 
     // 冻结为当前sheet页
     if (!order || order == getSheetIndex(Store.currentSheetIndex)) {
-        // let scrollLeft = $("#luckysheet-cell-main").scrollLeft();
+        let freezenverticaldata, col_st, left;
+        if (luckysheetFreezen.freezenRealFirstRowColumn) {
+            col_st = 0;
+            left = Store.visibledatacolumn[col_st] - 2 + Store.rowHeaderWidth;
+            freezenverticaldata = [
+                Store.visibledatacolumn[col_st],
+                col_st + 1,
+                0,
+                luckysheetFreezen.cutVolumn(Store.visibledatacolumn, col_st + 1),
+                left
+            ];
+        } else {
+            let scrollLeft = $("#luckysheet-cell-main").scrollLeft();
 
-        // let col_st = luckysheet_searcharray(Store.visibledatacolumn, scrollLeft);
-        // if(col_st == -1){
-        //     col_st = 0;
-        // }
-        let col_st = 0;
+            col_st = luckysheet_searcharray(Store.visibledatacolumn, scrollLeft);
+            if(col_st == -1){
+                col_st = 0;
+            }
 
-        // let left = Store.visibledatacolumn[col_st] - 2 - scrollLeft + Store.rowHeaderWidth;
-        let left = Store.visibledatacolumn[col_st] - 2 + Store.rowHeaderWidth;
-        let freezenverticaldata = [
-            Store.visibledatacolumn[col_st],
-            col_st + 1,
-            0,
-            luckysheetFreezen.cutVolumn(Store.visibledatacolumn, col_st + 1),
-            left
-        ];
+            left = Store.visibledatacolumn[col_st] - 2 - scrollLeft + Store.rowHeaderWidth;
+            freezenverticaldata = [
+                Store.visibledatacolumn[col_st],
+                col_st + 1,
+                scrollLeft,
+                luckysheetFreezen.cutVolumn(Store.visibledatacolumn, col_st + 1),
+                left
+            ];
+        }
+
         luckysheetFreezen.saveFreezen(null, null, freezenverticaldata, left);
 
         if (luckysheetFreezen.freezenhorizontaldata != null) {

--- a/src/locale/en.js
+++ b/src/locale/en.js
@@ -9265,7 +9265,8 @@ export default {
         freezenRCRange:"Freezen both range",
         freezenCancel:"Cancel",
 
-        noSeletionError:"No Range to be selected",
+        noSeletionError:"No Range to be selected",        rangeRCOverErrorTitle: "Freeze reminder",
+        rangeRCOverError: "The frozen pane is beyond the visible range, which will lead to abnormal operation. Please reset the frozen area."
     },
     sort:{
         "asc":"Ascending ",

--- a/src/locale/en.js
+++ b/src/locale/en.js
@@ -8878,7 +8878,7 @@ export default {
         textWrapMode: 'Text wrap mode',
         textRotate: 'Text rotate',
         textRotateMode: 'Text rotate mode',
-        freezeTopRow: 'Freeze top row',
+        freezeTopRow: 'Freeze first row',
         sortAndFilter: 'Sort and filter',
         findAndReplace: 'Find and replace',
         sum: 'SUM',

--- a/src/locale/es.js
+++ b/src/locale/es.js
@@ -9250,6 +9250,8 @@ export default {
         freezenCancel:"Cancelar",
 
         noSeletionError:"No hay rango para seleccionar",
+        rangeRCOverErrorTitle: "Recordatorio de congelación",
+        rangeRCOverError: "El panel de congelación excede el rango visible y puede causar que no funcione correctamente. Reinicie el área de congelación."
     },
     sort:{
         "asc":"Ascendente ",

--- a/src/locale/zh.js
+++ b/src/locale/zh.js
@@ -9486,7 +9486,7 @@ export default {
         default:"冻结第一行",
         freezenRow:"冻结第一行",
         freezenColumn:"冻结第A列",
-        freezenRC:"冻结行列",
+        freezenRC:"冻结第一行第A列",
         freezenRowRange:"冻结行到选区",
         freezenColumnRange:"冻结列到选区",
         freezenRCRange:"冻结行列到选区",

--- a/src/locale/zh.js
+++ b/src/locale/zh.js
@@ -9088,7 +9088,7 @@ export default {
         textWrapMode: '换行方式',
         textRotate: '文本旋转',
         textRotateMode: '旋转方式',
-        freezeTopRow: '冻结首行',
+        freezeTopRow: '冻结第一行',
         sortAndFilter: '排序和筛选',
         findAndReplace: '查找替换',
         sum: '求和',
@@ -9483,9 +9483,9 @@ export default {
         "rotationDown":"向下90°"
     },
     freezen:{
-        default:"冻结首行",
-        freezenRow:"冻结首行",
-        freezenColumn:"冻结首列",
+        default:"冻结第一行",
+        freezenRow:"冻结第一行",
+        freezenColumn:"冻结第A列",
         freezenRC:"冻结行列",
         freezenRowRange:"冻结行到选区",
         freezenColumnRange:"冻结列到选区",

--- a/src/locale/zh.js
+++ b/src/locale/zh.js
@@ -9493,6 +9493,8 @@ export default {
         freezenCancel:"取消冻结",
 
         noSeletionError:"没有选区",
+        rangeRCOverErrorTitle: "冻结提醒",
+        rangeRCOverError: "冻结窗格超过可见范围，会导致无法正常操作，请重新设置冻结区域。"
     },
     sort:{
         "asc":"升序",

--- a/src/locale/zh_tw.js
+++ b/src/locale/zh_tw.js
@@ -9486,6 +9486,8 @@ export default {
         freezenCancel     : "取消凍結",
 
         noSeletionError: "没有選區",
+        rangeRCOverErrorTitle: "凍結提醒",
+        rangeRCOverError: "凍結窗格超過可見範圍，會導致無法正常操作，請重新設定凍結區域。"
     },
     sort: {
         "asc"   : "昇冪",

--- a/src/locale/zh_tw.js
+++ b/src/locale/zh_tw.js
@@ -9089,7 +9089,7 @@ export default {
         textWrapMode       : '換行管道',
         textRotate         : '文字旋轉',
         textRotateMode     : '旋轉管道',
-        freezeTopRow       : '凍結首行',
+        freezeTopRow       : '凍結第一行',
         sortAndFilter      : '排序和篩選',
         findAndReplace     : '查找替換',
         sum                : '求和',
@@ -9476,9 +9476,9 @@ export default {
         "rotationDown": "向下90°"
     },
     freezen: {
-        default           : "凍結首行",
-        freezenRow        : "凍結首行",
-        freezenColumn     : "凍結首列",
+        default           : "凍結第一行",
+        freezenRow        : "凍結第一行",
+        freezenColumn     : "凍結第A列",
         freezenRC         : "凍結行列",
         freezenRowRange   : "凍結行到選區",
         freezenColumnRange: "凍結列到選區",


### PR DESCRIPTION
### 问题现象

#815 

冻结首行实际是冻结了当前视图的第一行

重现步骤：
1. 向下滚动若干行
2. 选择冻结首行
3. 当前屏幕内的第一行位置被冻结，如下图实际为25行

![](https://user-images.githubusercontent.com/13060680/139771504-f9919fa6-8e7a-48c1-93f1-1dd56ca31d27.gif)

### 任务合理的首行首列应为实际的第一行、第一列， 故做此修改。

新版效果：

![2021-11-12-新冻结](https://user-images.githubusercontent.com/13060680/141433027-e4992a3d-3583-4923-96e9-77d8b9fe8ff9.gif)

### 是bug还是feature？ 

在此过程中发现 office、wps 中的首行首列实际是指当前滚动区域内的第一行第一列，而非实际数据的第一行第一列。

![2021-11-11-excel冻结](https://user-images.githubusercontent.com/13060680/141433172-dbcd4eea-e306-4b1e-8a22-a90fffb1bc4b.gif)

照这个来看，luckysheet的表现是对的，但实际上luckysheet也存在问题。
如果是冻结滚动后视图的第一行第一列，那么仅仅存储 `{type: row }` 来表示首行就是不对的， 比如滚动到10行的位置，冻结，当前显示是冻结到第十行，第十行之前都看不到。 保存数据，再次进来，此时冻结变成了冻结第一行， 因此这是也个bug。

直觉理解上实际的第一更对，但以excel为标杆，则不是这样。

为了这个差异，修复是加了个标志位来判到底使用何种冻结方式。

```js
{
    // 定义冻结首行、首列是实际的第一行第一列还是当前视图的第一行第一列
    // excel 为视图的第一行第一列，但此处实现有问题，如滚动到15行冻结首行，当前冻结了15行，保存再进去实际冻结了第一行
    // 冻结真实的第一行、第一列更符合直觉
    freezenRealFirstRowColumn: true
}
```

将此值设置为false就是之前的表现， true就是冻结实际第一行第一列的表现。