### PR TITLE
fix: 解决容器id不是luckysheet时，点击工具栏中 “更多” 按钮，出现的偏移位置出错的问题

### DIFF
--- a/src/controllers/resize.js
+++ b/src/controllers/resize.js
@@ -167,7 +167,8 @@ export default function luckysheetsizeauto(isRefreshCanvas=true) {
             //When resize, change the width of the more button container in real time
             $$('#luckysheet-icon-morebtn-div').style.left = '';//reset
 
-            const containerLeft = $$('#luckysheet').getBoundingClientRect ? $$('#luckysheet').getBoundingClientRect().left : 0;
+            // *这里计算containerLeft的作用是：获得容器左侧的margin值，以让点击出现的“更多按钮”栏位置不会出错。
+            const containerLeft = $$(`#${Store.container}`).getBoundingClientRect ? $$(`#${Store.container}`).getBoundingClientRect().left : 0;
             const morebtnLeft = $$('#luckysheet-icon-morebtn-div').getBoundingClientRect().left;//get real left info
 
             if(morebtnLeft < containerLeft){


### PR DESCRIPTION
 #579 #845 

跟579这个issue是同个问题导致，之前有人修了一版加了个判断，但并没有解决根本问题。

**复现场景：**
1. luckysheet引入在项目中，表格的容器不是全屏（容器左侧有margin值）
2. 容器的ID不设为luckysheet
3. 点击“更多按钮”
4. 能够发现更多按钮的出现错位

**修改前截图：**
![修改前问题](https://user-images.githubusercontent.com/46434433/141710660-2650a8ed-f7cd-4242-8b08-d6188cf9479f.gif)

**修改后效果图**
![修改后效果](https://user-images.githubusercontent.com/46434433/141714178-baf5f7c8-9a41-44eb-8d51-0780f69208f8.gif)

