### PR TITLE
fix: 修复右键添加多列时，添加出来的cell单元格数据会同步的问题

### DIFF
--- a/src/global/extend.js
+++ b/src/global/extend.js
@@ -917,16 +917,18 @@ function luckysheetextendtable(type, index, value, direction, sheetIndex) {
             let row = d[r];
 
             for(let i = 0; i < value; i++){
+                // *这里不能是引用,不然添加多列时添加的都是同一个引用,修改一个cell会同步到多个
+                const COLR = JSON.parse(JSON.stringify(col[r]))
                 if(direction == "lefttop"){
                     if(index == 0){
-                        row.unshift(col[r]);
+                        row.unshift(COLR);
                     }
                     else{
-                        row.splice(index, 0, col[r]);
+                        row.splice(index, 0, COLR);
                     }
                 }
                 else{
-                    row.splice((index + 1), 0, col[r]);
+                    row.splice((index + 1), 0, COLR);
                 }
             }
         }


### PR DESCRIPTION

**复现场景：**
1. 鼠标右键，添加多列
2. 在添加出来的单元格内输入
3. 查看

**修改前截图：**
![修改前问题](https://user-images.githubusercontent.com/46434433/142821125-c58b191f-4e92-461e-8610-efb217db2c83.gif)


**修改后截图：**
![修改后效果](https://user-images.githubusercontent.com/46434433/142821133-6add5aeb-5d24-4a36-b2ce-88182761d558.gif)
