### PR TITLE
fix: 修复协同编辑情况下，他人正在编辑时，修改行高列宽和添加行列报错的问题

### DIFF
--- a/src/controllers/server.js
+++ b/src/controllers/server.js
@@ -255,7 +255,7 @@ const server = {
 					if(flag) {
 						Store.cooperativeEdit.changeCollaborationSize.forEach(val => {
 							if(val.id == id) {
-								val.v = item.v[0]
+								val.v = item.v[0] || item.range[0]
 								val.i = index
 							}
 						})


### PR DESCRIPTION

 **复现步骤：**
1. 用户B进入编辑，用户A出现用户B的光标提示
2. 用户A点击新增列
3. A报错

**修改前gif：**
![修改前问题](https://user-images.githubusercontent.com/46434433/143553920-47c53b91-e821-46df-a47f-306e0468198b.gif)


**修改后gif：**
![修改后效果](https://user-images.githubusercontent.com/46434433/143553935-6be735c4-70aa-4fa0-8878-dd4ce4124d3e.gif)
