### PR TITLE
fix(server.js): 修复协同编辑器i情况下，如果光标在左上的边接处显示不全的问题

### DIFF
--- a/src/controllers/server.js
+++ b/src/controllers/server.js
@@ -989,17 +989,26 @@ const server = {
 
 	        col = margeset.column[1];
 	        col_pre = margeset.column[0];
-		}
+			}
 
-		// 超出16个字符就显示...
-		if(getByteLen(name) > 16){
-			name = getByteLen(name,16) + "...";
-		}
+			// *处理光标在靠左或者靠上顶着的时候，光标显示不全的问题
+			if(col_pre <= 0){
+				col_pre += 1
+			}
 
-		// 如果正在编辑，就显示“正在输入”
-		if(value === 'enterEdit'){
-			name += " " + locale().edit.typing;
-		}
+			if(row_pre <= 0){
+				row_pre +=1
+			}
+
+			// 超出16个字符就显示...
+			if(getByteLen(name) > 16){
+				name = getByteLen(name,16) + "...";
+			}
+
+			// 如果正在编辑，就显示“正在输入”
+			if(value === 'enterEdit'){
+				name += " " + locale().edit.typing;
+			}
 
 	    if($("#luckysheet-multipleRange-show-" + id).length > 0){
 			$("#luckysheet-multipleRange-show-" + id).css({ "position": "absolute", "left": col_pre - 1, "width": col - col_pre - 1, "top": row_pre - 1, "height": row - row_pre - 1 });


### PR DESCRIPTION
**问题描述：**

协同编辑情况下，当光标选在了左上靠边的位置时，显示的光标会被遮挡


**问题截图：**
![5eb4338d2ab4497b98a0bd8948bec591](https://user-images.githubusercontent.com/46434433/147209754-b57e4356-8462-46e2-bc26-a40681386d5b.png)
