### PR TITLE
fix(src/controllers/inlinestring.js updateinlinestringformat): 内联样式设置的时候，会对部分内容失效

### DIFF
--- a/src/controllers/inlineString.js
+++ b/src/controllers/inlineString.js
@@ -186,7 +186,8 @@ export function updateInlineStringFormat(cell, attr, value, $input){
                 if(startSpanIndex<endSpanIndex){
                     for(let i=startSpanIndex+1;i<endSpanIndex;i++){
                         let span = spans.get(i), content = span.innerHTML;
-                        cont += "<span style='"+ span.style.cssText +"'>" + content + "</span>";
+                        let cssText = getCssText(span.style.cssText, attr, value);
+                        cont += "<span style='"+ cssText +"'>" + content + "</span>";
                     }
                 }
 


### PR DESCRIPTION
假设一个单元格的内容是luckysheet,其中ky两个字母是设置了加粗的样式,
那此时如果我选中luckysheet,也就是选中全部,给选中的内容设置一个删除线的样式.
得到的效果会是:
只有luc和sheet才有斜体的效果,而ky并没有被设置成删除线样式.
这和用户预期的效果的不一致. 
具体可以看issue描述

fix # 917

https://github.com/mengshukeji/Luckysheet/issues/917