### PR TITLE
fix: dropCell.update function

### DIFF
--- a/src/controllers/dropCell.js
+++ b/src/controllers/dropCell.js
@@ -485,7 +485,7 @@ const luckysheetDropCell = {
                             let f = "=" + formula.functionCopy(cell.f, "down", j - apply_str_r + 1);
                             let v = formula.execfunction(f, j, i);
 
-                            formula.execFunctionGroup(i, j, v[1], undefined, d);
+                            formula.execFunctionGroup(j, i, v[1], undefined, d);
 
                             cell.f = v[2];
                             cell.v = v[1];
@@ -581,7 +581,7 @@ const luckysheetDropCell = {
                             let f = "=" + formula.functionCopy(cell.f, "up", apply_end_r - j + 1);
                             let v = formula.execfunction(f, j, i);
 
-                            formula.execFunctionGroup(i, j, v[1], undefined, d);
+                            formula.execFunctionGroup(j, i, v[1], undefined, d);
 
                             cell.f = v[2];
                             cell.v = v[1];


### PR DESCRIPTION
In the function called execFunctionGroup, the row and col arguments are mixed up in places