### PR TITLE
fix: computeRowlenByContent function, skip hidden columns

### DIFF
--- a/src/global/getRowlen.js
+++ b/src/global/getRowlen.js
@@ -116,6 +116,10 @@ function computeRowlenByContent(d, r) {
             }
         }
 
+        if(Store.config["colhidden"] != null && Store.config["colhidden"][c] != null){
+            continue;
+        }
+
 
         if(cell != null && (cell.v != null || isInlineStringCell(cell)) ){
             let cellWidth = computeCellWidth(cell, c);


### PR DESCRIPTION
The computeRowlenByContent function performs calculation for hidden columns too and it's affect on view