### PR TITLE
修复行高自适应场景问题、部分样式时回车换行样式覆盖问题

### DIFF
--- a/src/controllers/inlineString.js
+++ b/src/controllers/inlineString.js
@@ -72,7 +72,7 @@ export function updateInlineStringFormat(cell, attr, value, $input){
         if(startContainer===endContainer){
             let span = startContainer.parentNode, spanIndex, inherit=false;
             
-            let content = span.innerHTML;
+            let content = span.innerText;
 
             let fullContent = $textEditor.html();
             if(fullContent.substr(0,5) != "<span"){
@@ -303,8 +303,11 @@ export function enterKeyControll(cell){
             $(startSpan).replaceWith(cont);
         }
         else{
+            // 这里不能取整个单元格的样式，因为如果设置了部分样式的话就会出问题
+            // let cssText = getFontStyleByCell(cell);
             
-            let cssText = getFontStyleByCell(cell);
+            let cssText = startSpan.style.cssText;
+
             if(sright==""){
                 cont = "<span style='"+ cssText +"'>" + sleft + "\n\n" + "</span>";
             }

--- a/src/global/formula.js
+++ b/src/global/formula.js
@@ -1562,7 +1562,9 @@ const luckysheetformula = {
             cfg["rowlen"] = {};
         }
 
-        if ((d[r][c].tb == "2" && d[r][c].v != null) || isInlineStringCell(d[r][c])) {//自动换行
+        // 单元格行高自适应,只有在单元格不是合并单元格时才能生效
+        if ((d[r][c].tb == "2" && d[r][c].v != null) || isInlineStringCell(d[r][c]) && (typeof d[r][c]['mc'] == 'undefined')) {
+            //自动换行
             let defaultrowlen = Store.defaultrowlen;
 
             let canvas = $("#luckysheetTableContent").get(0).getContext("2d");


### PR DESCRIPTION
**1.部分样式回车换行覆盖问题：**
![部分样式覆盖问题](https://user-images.githubusercontent.com/46434433/167054009-6d60a71e-99c0-4945-93b2-5cdd2fcabf26.gif)
 
2.当单元格是合并单元格时，不应该自适应行高