### PR TITLE
fixed：某些极限情况下合并单元格的列宽计算错误

### DIFF
--- a/src/global/getRowlen.js
+++ b/src/global/getRowlen.js
@@ -148,7 +148,7 @@ function computeRowlenByContent(d, r) {
 
 function computeCellWidth(cell, col_index) {
     let colLocationArr = colLocationByIndex(col_index);
-    if (cell.mc && cell.mc.c !== cell.mc.cs) {
+    if (cell.mc && 1 !== cell.mc.cs) {
         colLocationArr = colSpanLocationByIndex(col_index, cell.mc.cs);
     }
 


### PR DESCRIPTION
文档中描述 cell.mc.cs 为 合并单元格占的列数

原代码使用 mc.c !== mc.cs 意为 开始列不等于合并列数？

在实际使用中遇到了，第3列刚好合并了3列，跳过了这个if，导致列宽计算出来依然是第3列的列宽

应当是合并列数为1的时候 ( 即只合并了行，没有合并列 )跳过