### PR TITLE
feat: allow library users to add locales

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -2,6 +2,7 @@
 import defaultSetting from './config.js';
 import { common_extend } from './utils/util';
 import Store from './store';
+import { locales } from './locale/locale';
 import server from './controllers/server';
 import luckysheetConfigsetting from './controllers/luckysheetConfigsetting';
 import sheetmanage from './controllers/sheetmanage';
@@ -252,6 +253,8 @@ luckysheet.destroy = method.destroy;
 luckysheet.showLoadingProgress = showloading;
 luckysheet.hideLoadingProgress = hideloading;
 luckysheet.luckysheetextendData = luckysheetextendData;
+
+luckysheet.locales = locales;
 
 export {
     luckysheet

--- a/src/locale/locale.js
+++ b/src/locale/locale.js
@@ -4,10 +4,10 @@ import es from './es'
 import zh_tw from './zh_tw'
 import Store from '../store';
 
-const localeObj = {en,zh,es,zh_tw}
+export const locales = {en,zh,es,zh_tw}
 
 function locale(){
-    return localeObj[Store.lang];
+    return locales[Store.lang];
 }
 
 export default locale;


### PR DESCRIPTION
This PR exposes the `localeObj` of `locale.js` by including it in the core `luckysheet` object with the name `locales`.
This allows library users to add locales.

```js
luckysheet.locales.ja = { ... };
```

In some cases, it is not practical to translate all the localizable words, but only some of them.
Such cases can also be handled.

```js
luckysheet.locales.ja = {
    ...luckysheet.locales.en,
    toolbar: {
        ...luckysheet.locales.en.toolbar,
        undo: '元に戻す',
    },
};
```
