### PR TITLE
fix: case-insensitive search becomes case-sensitive

### DIFF
--- a/src/controllers/searchReplace.js
+++ b/src/controllers/searchReplace.js
@@ -450,10 +450,20 @@ const luckysheetSearchReplace = {
                                 }
                             }
                             else{
-                                if(~value.indexOf(searchText)){
-                                    if(!((r + "_" + c) in obj)){
-                                        obj[r + "_" + c] = 0;
-                                        arr.push({"r": r, "c": c});
+                                if(caseCheck){
+                                    if(~value.indexOf(searchText)){
+                                        if(!((r + "_" + c) in obj)){
+                                            obj[r + "_" + c] = 0;
+                                            arr.push({"r": r, "c": c});
+                                        }
+                                    }
+                                }
+                                else{
+                                    if(~value.toLowerCase().indexOf(searchText.toLowerCase())){
+                                        if(!((r + "_" + c) in obj)){
+                                            obj[r + "_" + c] = 0;
+                                            arr.push({"r": r, "c": c});
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
On the latest `master` branch, case-insensitive searches work as case-sensitive searches.

It seems to be a degrade due to the following commit:
https://github.com/mengshukeji/Luckysheet/commit/6970f47f8475d754069040c76219eea69a7f4a70

This PR fixes the case-insensitive search.