### PR TITLE
fix: 修复调用 setSheetZoom API时图片未更新的问题

### DIFF
--- a/src/global/api.js
+++ b/src/global/api.js
@@ -5479,7 +5479,12 @@ export function setSheetZoom(zoom, options = {}) {
 
     if(file.index == Store.currentSheetIndex){
         Store.zoomRatio = zoom;
-
+        // 图片
+        let currentSheet = sheetmanage.getSheetByIndex();
+        imageCtrl.images = currentSheet.images;
+        imageCtrl.allImagesShow();
+        imageCtrl.init();
+        
         zoomNumberDomBind();
         zoomRefreshView();
     }


### PR DESCRIPTION
在实际使用中遇到仅缩放操作按钮能更新图片位置及大小，setSheetZoom API不能