### PR TITLE
Fix datediff

### DIFF
--- a/src/function/functionImplementation.js
+++ b/src/function/functionImplementation.js
@@ -12485,8 +12485,9 @@ const functionImplementation = {
                     result = (startM <= endM) ?  endM - startM : endM + 12 - startM;
                     break;
                 case "YD":case "yd":
-                    var startM = genarate(startDate.format('MM-DD'))[2];
-                    var endM = genarate(endDate.format('MM-DD'))[2];
+                    const format = `${endDate.$y}-MM-DD`;
+                    var startM = genarate(startDate.format(format))[2];
+                    var endM = genarate(endDate.format(format))[2];
 
                     result = (startM <= endM) ? endM - startM : endM + 365 - startM;
                     break;

--- a/src/function/functionImplementation.js
+++ b/src/function/functionImplementation.js
@@ -12451,9 +12451,8 @@ const functionImplementation = {
         }
 
         try {
-            luckysheet_getValue(arguments);
             for (var i = 0; i < arguments.length-1; i++){
-                arguments[i] = moment.fromOADate(arguments[i]).format("l");
+                arguments[i] = func_methods.getCellDate(arguments[i]);
                 if(!isdatetime(arguments[i])){
                     return formula.error.v;
                 }


### PR DESCRIPTION
"moment" - don't use what caused the error anymore.
format ('MM-DD') without a year cannot parse the date correctly (returns a string)